### PR TITLE
Add create route

### DIFF
--- a/src/emotions-manage/emotions-m.controller.js
+++ b/src/emotions-manage/emotions-m.controller.js
@@ -6,3 +6,13 @@ export const getEmotionsManageInfo = async (req, res) => {
   const emotions = await col.find().toArray(); // busco TODOS y lo paso a array
   res.json(emotions); // devuelvo el resultado al cliente
 };
+
+// CREATE ONE
+export const createEmotionManage = (req, res) => {
+  const { title, emotionsManage, image } = req.body // Get the emotion data from the request body
+
+  const db = req.app.locals.ddbbClient.db("final-project"); // cojo la BBDD
+  const col = db.collection("emotions-manage") // cojo la collection
+  col.insertOne({ title, emotionsManage, image });
+  res.sendStatus(200);
+}

--- a/src/emotions-manage/emotions-m.router.js
+++ b/src/emotions-manage/emotions-m.router.js
@@ -1,8 +1,10 @@
 import express from "express";
-import { getEmotionsManageInfo } from "./emotions-m.controller.js";
+import { createEmotionManage, getEmotionsManageInfo } from "./emotions-m.controller.js";
 
 const router = express.Router();
 
 router.route("/").get(getEmotionsManageInfo);
+
+router.route("/create").post(createEmotionManage);
 
 export default router;


### PR DESCRIPTION
# Description

This PR creates a new route in the backend accessible in `.../emotions-manage/create` where the user can add a new emotion to the collection emotions-manage using POST method.

For an example on how to connect to this endpoint see this Codesandbox: https://codesandbox.io/s/connect-to-emotions-manage-create-endpoint-9e24v2. You can test the implementation running the backend locally and then submitting the form.